### PR TITLE
fix loop simplifier

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/kfg/analysis/LoopSimplifier.kt
+++ b/src/main/kotlin/org/jetbrains/research/kfg/analysis/LoopSimplifier.kt
@@ -99,6 +99,9 @@ class LoopSimplifier(override val cm: ClassManager) : LoopVisitor {
         header.handlers.forEach { mapToCatch(header, preheader, it) }
         preheader += inst(cm) { goto(header) }
         current.addBefore(header, preheader)
+        if (loop.hasParent) {
+            loop.parent.addBlock(preheader)
+        }
     }
 
     private fun buildLatch(loop: Loop) = with(ctx) {


### PR DESCRIPTION
After nested loop simplification parent loop becomes incorrect and simplifier fail with `KtException("Can't simplify loop with multiple entries")`

Example:
```kotlin
    fun complexLoop2(x: Boolean) {
        for (j in 0..17) {
            val b = 2
            for (i in 0..10) {
                val c = 3
                try {
                    val e = 5
                } catch (e: Exception) {
                    continue
                }
                if (x) {
                    val f = 6
                    continue
                }
                break
            }
        }
    }
```